### PR TITLE
feat(no_queries_attribute): Support of no "queries" attribute for query-selector

### DIFF
--- a/components/packages/query-selector/src/query-selector.ts
+++ b/components/packages/query-selector/src/query-selector.ts
@@ -6,7 +6,7 @@ import 'pagination-selector';
 @customElement('query-selector')
 export class QuerySelector extends LitElement {
   @property({ type: Object, reflect: true })
-  private queries: any;
+  private queries: any = JSON.parse('{"defaultQuery": [], "additionalQuery": []}');
 
   @property({ type: String })
   private selectedQuery = '';

--- a/components/packages/query-selector/test/query-selector.test.js
+++ b/components/packages/query-selector/test/query-selector.test.js
@@ -167,6 +167,15 @@ describe('query-selector', () => {
         expect(pageNumberValue).to.equal("1");
     });
 
+    it('Should component behave correctly when queries attribute is not provided', async () => {
+        querySel = await fixture(html`<query-selector></query-selector>`);
+        const queryLinesDefault = getQueries(querySel, '#defaultQueries');
+        const queryLinesAdditional = getQueries(querySel, '#additionalQueries');
+
+        expect(queryLinesDefault.length).equal(0);
+        expect(queryLinesAdditional.length).equal(0);
+    });
+
     function getQuerySelector() {
         return fixture(html`
       <query-selector


### PR DESCRIPTION
If query-selector has no "queries" attribute, the component is displayed, with empty query lists (was not displaying anything before)