### PR TITLE
feat(UID-233_init_attribute_contd) : 'init' attribute cont'd

### DIFF
--- a/components/packages/query-selector/src/query-selector.ts
+++ b/components/packages/query-selector/src/query-selector.ts
@@ -41,6 +41,7 @@ export class QuerySelector extends LitElement {
   private filterTitle: string = "";
   private defaultSelectedIndex: number | undefined = undefined;
   private additionalSelectedIndex: number | undefined = undefined;
+  private initialized: boolean = false;
 
     constructor() {
         super();
@@ -48,6 +49,17 @@ export class QuerySelector extends LitElement {
             this.filterTitlePrefix = get("filterTitlePrefix");
             this.filterTitle = this.filterTitlePrefix;
         });
+    }
+
+    async performUpdate() {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+      // Initialize if we have the 'init' attribute and the queries has been set
+      if (!this.initialized && this.init && this.init.query && !this.isDefaultQueries(this.queries)) {
+        this.initSelect(this.init.query.name);
+        this.initialized = true;
+        this.render();
+      }
+      super.performUpdate();
     }
 
     async connectedCallback() {
@@ -265,9 +277,11 @@ export class QuerySelector extends LitElement {
 
   private filterArgChanged(arg: string, value: string) {
     Object.assign(arg, { value: value });
+    let event: any = {"query": {"name": this.selectedQuery}};
+    event.filters = this.filterArgs;
     this.dispatchEvent(
       new CustomEvent('filterChanged', {
-        detail: this.filterArgs,
+        detail: event,
         bubbles: true,
         composed: true,
       }),
@@ -350,5 +364,9 @@ export class QuerySelector extends LitElement {
 
   private static getDefaultQueriesAttribute(): Object {
     return JSON.parse('{"defaultQuery": [], "additionalQuery": []}');
+  }
+
+  private isDefaultQueries(newQueries: Object) : boolean {
+      return JSON.stringify(QuerySelector.getDefaultQueriesAttribute()) === JSON.stringify(newQueries);
   }
 }

--- a/components/packages/query-selector/test/query-selector.test.complex.js
+++ b/components/packages/query-selector/test/query-selector.test.complex.js
@@ -61,7 +61,7 @@ describe('query-selector', () => {
                 const additionalQueriesLines = getQueries(querySel, '#additionalQueries');
                 expect(additionalQueriesLines.length).equal(1);
                 resolve();
-            }, 0);
+            }, 100);
         });
         // wait for the promise is done
         await promise.then(() => {
@@ -102,7 +102,7 @@ describe('query-selector', () => {
                 expect(argLabel.length).to.equal(1);
                 expect(argLabel[0].innerText).to.equal("name");
                 resolve();
-            }, 0);
+            }, 100);
         });
         // wait for the promise is done
         await promise.then(() => {
@@ -117,7 +117,7 @@ describe('query-selector', () => {
             'filterChanged',
             e => {
                 eventReceived = true;
-                filterValue = e.detail[0].value;
+                filterValue = e.detail.filters[0].value;
             }
         );
 
@@ -130,7 +130,7 @@ describe('query-selector', () => {
                 // Value changed from js does not send the 'input' event: simulate it
                 argInput[0].dispatchEvent(new Event("input"));
                 resolve();
-            }, 0);
+            }, 100);
         });
         // wait for the promise is done
         await promise.then(() => {


### PR DESCRIPTION
This is the continuation of UID-233 feature.
This fix allows to handle the 'init' attribute even if the 'queries' attribute is set after it. 
Additionally, the 'filterChanged' attribute as been updated to provide the selected query.